### PR TITLE
Unwhitened peak channel

### DIFF
--- a/ecephys_spike_sorting/modules/mean_waveforms/__main__.py
+++ b/ecephys_spike_sorting/modules/mean_waveforms/__main__.py
@@ -68,10 +68,11 @@ def calculate_mean_waveforms(args):
                     args['ephys_params']['bit_volts'], \
                     args['ephys_params']['sample_rate'], \
                     args['ephys_params']['vertical_site_spacing'], \
-                    args['mean_waveform_params'])
-                
-        metrics.to_csv(args['waveform_metrics']['waveform_metrics_file'])      
-        
+                    args['mean_waveform_params'], \
+                    args['directories']['kilosort_output_directory'])
+
+        metrics.to_csv(args['waveform_metrics']['waveform_metrics_file'])
+
     else:
         
         print('Calculating mean waveforms using python.')

--- a/ecephys_spike_sorting/modules/mean_waveforms/metrics_from_file.py
+++ b/ecephys_spike_sorting/modules/mean_waveforms/metrics_from_file.py
@@ -89,6 +89,15 @@ def metrics_from_file(mean_waveform_fullpath,
     # initialize peak_channels array
     peak_channels = np.zeros([nTemplate, ], 'uint32')
 
+    # for each template (nt x nchan), multiply the the transpose (nchan x nt) by inverse of
+    # the whitening matrix (nchan x nchan); get max and min along tthe time axis (1)
+    # to find the peak channel
+    for i in np.arange(0, nTemplate):
+        currT = templates[i, :].T
+        curr_unwh = np.matmul(w_inv, currT)
+        currdiff = np.max(curr_unwh, 1) - np.min(curr_unwh, 1)
+        peak_channels[i] = channel_map[np.argmax(currdiff)]
+
     for cluster_idx, cluster_id in enumerate(cluster_ids):
 
         printProgressBar(cluster_idx+1, total_units)

--- a/ecephys_spike_sorting/modules/mean_waveforms/metrics_from_file.py
+++ b/ecephys_spike_sorting/modules/mean_waveforms/metrics_from_file.py
@@ -81,7 +81,10 @@ def metrics_from_file(mean_waveform_fullpath,
     mean_waveforms = np.load(mean_waveform_fullpath)
     snr_array = np.load(snr_fullpath)
 
-
+    templates = np.load(os.path.join(output_dir, 'templates.npy'))
+    channel_map = np.load(os.path.join(output_dir, 'channel_map.npy'))
+    channel_map = np.squeeze(channel_map)
+    
     # read in inverse of whitening matrix
     w_inv = np.load((os.path.join(output_dir, 'whitening_mat_inv.npy')))
     nTemplate = templates.shape[0]

--- a/ecephys_spike_sorting/modules/mean_waveforms/metrics_from_file.py
+++ b/ecephys_spike_sorting/modules/mean_waveforms/metrics_from_file.py
@@ -13,16 +13,16 @@ from ...common.utils import printProgressBar
 
 def metrics_from_file(mean_waveform_fullpath,
                       snr_fullpath,
-                      spike_times, 
-                      spike_clusters, 
-                      templates, 
-                      channel_map, 
-                      bit_volts, 
-                      sample_rate, 
-                      site_spacing, 
-                      params):
-                     
-    
+                      spike_times,
+                      spike_clusters,
+                      templates,
+                      channel_map,
+                      bit_volts,
+                      sample_rate,
+                      site_spacing,
+                      params,output_dir):
+
+
     """
     Load C_waves output and call waveform_metrics for each cluster
     Does not support epochs, since waveforms are already averaged
@@ -82,9 +82,13 @@ def metrics_from_file(mean_waveform_fullpath,
     snr_array = np.load(snr_fullpath)
 
 
-    peak_channels = np.squeeze(channel_map[np.argmax(np.max(templates,1) - np.min(templates,1),1)])
-    
-    
+    # read in inverse of whitening matrix
+    w_inv = np.load((os.path.join(output_dir, 'whitening_mat_inv.npy')))
+    nTemplate = templates.shape[0]
+
+    # initialize peak_channels array
+    peak_channels = np.zeros([nTemplate, ], 'uint32')
+
     for cluster_idx, cluster_id in enumerate(cluster_ids):
 
         printProgressBar(cluster_idx+1, total_units)


### PR DESCRIPTION
Save to csv the unwhitened peak channel (mean_waveform module). I was running in an error when caluclating the peak times https://github.com/jenniferColonell/ecephys_spike_sorting/blob/ada8b0b8706c1ffb155a9c0fa5614c88e7436a0f/ecephys_spike_sorting/modules/mean_waveforms/__main__.py#L63
https://github.com/jenniferColonell/ecephys_spike_sorting/blob/ada8b0b8706c1ffb155a9c0fa5614c88e7436a0f/ecephys_spike_sorting/modules/mean_waveforms/metrics_from_file.py#L85

Using the unwhitened template solves it somehow, don't get why actually. Just copied from your last commit ada8b0b8706c1ffb155a9c0fa5614c88e7436a0f .