### PR TITLE
fixed depth estimation during drift map plotting

### DIFF
--- a/ecephys_spike_sorting/common/visualization.py
+++ b/ecephys_spike_sorting/common/visualization.py
@@ -148,7 +148,7 @@ def plotDriftmap(ks_directory, sample_rate = 30000, time_range = [0, np.inf], ex
                     use_master_clock = False,
                     include_pcs = True)
 
-    spike_depths = get_spike_depths(spike_clusters, pc_features, pc_feature_ind, channel_pos)
+    spike_depths = get_spike_depths(spike_clusters, np.squeeze(spike_templates), np.square(pc_features[:,0,:]), pc_feature_ind, channel_pos)
     spike_amplitudes = get_spike_amplitudes(spike_templates, templates, amplitudes)
 
     if exclude_noise:


### PR DESCRIPTION
The parameter signature for the "get_spike_depths" method in the common.utils module was [updated](https://github.com/jenniferColonell/ecephys_spike_sorting/commit/4319810b106bc642fb1b59967dfefae7d5481550) ([twice](https://github.com/jenniferColonell/ecephys_spike_sorting/commit/ae7b75e95eabf9af9d5cc1bd6b249b69c42a8bc3)) through 2021, while its usage in the commons.visualization module is not updated since 2019, causing the  commons.visualization.plotDriftmap() function to fail when called. This patch corrected the problem.